### PR TITLE
Update elasticsearch to 7.8.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ checksum = "b3ec9c7fb9a2ce708751c98e31ccbae74b6ab194f5c8e30cfb7ed62e38b70866"
 
 [[package]]
 name = "elasticsearch"
-version = "7.7.1-alpha.1"
+version = "7.8.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784225c9e158d39f75a69918f68bd09e93c0d06f011eb85b2517721c34218e31"
+checksum = "ceb9ea158263eb216a652ec7901d72aee8a60d412106e6600990223f40c79837"
 dependencies = [
  "base64 0.11.0",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A simple command line interface for Elasticsearch queries."
 edition = "2018"
 
 [dependencies]
-elasticsearch = "7.7.1-alpha.1"
+elasticsearch = "7.8.0-alpha.1"
 serde_json = "~1"
 structopt = "0.3"
 tokio = { version = "0.2", features = ["full"] }


### PR DESCRIPTION
This commit updates the elasticsearch package
to 7.8.0-alpha.1